### PR TITLE
Fix to few values innitialised

### DIFF
--- a/PortScanner.go
+++ b/PortScanner.go
@@ -74,7 +74,7 @@ func (h PortScanner) hostPort(port int) string {
 
 const UNKNOWN = "<unknown>"
 
-func (h PortScanner) openConn(host string) (*net.TCPConn, error) {
+func (h PortScanner) openConn(host string) (net.Conn, error) {
 	tcpAddr, err := net.ResolveTCPAddr("tcp4", host)
 	if err != nil {
 		return nil, err

--- a/PortScanner.go
+++ b/PortScanner.go
@@ -12,25 +12,26 @@ import (
 	"fmt"
 	//	"io/ioutil"
 	//	"strings"
+	"time"
+
 	"github.com/anvie/port-scanner/predictors"
 	"github.com/anvie/port-scanner/predictors/webserver"
-	"time"
 )
 
 type PortScanner struct {
 	host       string
 	predictors []predictors.Predictor
-	timeout    int
+	timeout    time.Duration
 }
 
-func NewPortScanner(host string) *PortScanner {
+func NewPortScanner(host string, timeout time.Duration) *PortScanner {
 	return &PortScanner{host, []predictors.Predictor{
 		&webserver.ApachePredictor{},
 		&webserver.NginxPredictor{},
-	},
+	}, timeout,
 	}
 }
-func (h PortScanner) SetTimeout(timeout int) {
+func (h PortScanner) SetTimeout(timeout time.Duration) {
 	h.timeout = timeout
 }
 func (h PortScanner) RegisterPredictor(predictor predictors.Predictor) {


### PR DESCRIPTION
# What

While testing port scanner with go1.6 I discovered that it fails with initialising `PortScanner` struct. It throws such error:

```
combor/port-scanner/PortScanner.go:27: too few values in struct initializer
combor/port-scanner/PortScanner.go:50: cannot use h.timeout (type int) as type time.Duration in argument to net.DialTimeout
combor/port-scanner/PortScanner.go:82: cannot use h.timeout (type int) as type time.Duration in argument to net.DialTimeout
```

Additionaly there is a wrong type returned in `openConn` method:

```
combor/port-scanner/PortScanner.go:90: cannot use conn (type net.Conn) as type *net.TCPConn in return argument: need type assertion
```
# How to test

Run the code from README but with modified call to `NewPortScanner` :

```
  timeout := 100 * time.Millisecond
  ps := portscanner.NewPortScanner(host, timeout)

  // get opened port
  fmt.Printf("scanning port %d-%d...\n", 20, 65535)

  openedPorts := ps.GetOpenedPort(20, 30000)

  for i := 0; i < len(openedPorts); i++ {
    port := openedPorts[i]
    fmt.Print(" ", port, " [open]")
    fmt.Println("  -->  ", ps.DescribePort(port))
  }
```
