### PR TITLE
Added mutex lock to array modification

### DIFF
--- a/PortScanner.go
+++ b/PortScanner.go
@@ -13,6 +13,7 @@ import (
 	//	"io/ioutil"
 	//	"strings"
 	"time"
+	"sync"
 
 	"github.com/anvie/port-scanner/predictors"
 	"github.com/anvie/port-scanner/predictors/webserver"
@@ -68,12 +69,15 @@ func (h PortScanner) IsOpen(port int) bool {
 
 func (h PortScanner) GetOpenedPort(portStart int, portEnds int) []int {
 	rv := []int{}
+	l := sync.Mutex{}
 	sem := make(chan bool, h.threads)
 	for port := portStart; port <= portEnds; port++ {
 		sem <- true
 		go func(port int) {
 			if h.IsOpen(port) {
+				l.Lock()
 				rv = append(rv, port)
+				l.Unlock()
 			}
 			<- sem
 		}(port)


### PR DESCRIPTION
When using any amount of threads higher than 1, the access to the `rv` int slice is unsafe and may cause loss of data, causing results previously inserted to be thrown away.
By adding a mutex lock to the array modification, this problem is solved.